### PR TITLE
Selective LLM gating: safe/smart post-edit modes, heuristics, and chunk planner

### DIFF
--- a/src/local_translator/config.py
+++ b/src/local_translator/config.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+PostEditPolicy = Literal["off", "auto", "safe", "smart"]
+
 from local_translator.models.types import EngineMode
 
 LanguageCode = Literal["fr", "en"]
@@ -21,6 +23,10 @@ class LLMSettings:
     strict_validation: bool = True
     fallback_to_argos: bool = True
     max_expansion_ratio: float = 1.4
+    postedit_mode: PostEditPolicy = "auto"
+    skip_short_characters: int = 48
+    skip_high_placeholder_ratio: float = 0.12
+    smart_min_chars: int = 160
 
 
 @dataclass(slots=True)

--- a/src/local_translator/engines/llm_engine.py
+++ b/src/local_translator/engines/llm_engine.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Literal
 
 LOGGER = logging.getLogger(__name__)
+PostEditMode = Literal["safe", "smart"]
 
 
 class LLMEngine:
@@ -54,37 +56,62 @@ class LLMEngine:
         )
         return self._llm
 
-    def _build_prompt(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def _build_prompt(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: PostEditMode = "safe",
+    ) -> str:
         glossary_lines = "\n".join(f"- {k} => {v}" for k, v in (glossary or {}).items()) or "(none)"
+        mode_rules = {
+            "safe": (
+                "SAFE MODE:\n"
+                "- Make minimal edits only (grammar, agreement, punctuation, light wording).\n"
+                "- Prefer source-faithful phrasing over stylistic rewrites.\n"
+            ),
+            "smart": (
+                "SMART MODE:\n"
+                "- Improve fluency and readability while preserving exact meaning.\n"
+                "- You may reorder clauses and tighten wording, but keep scope and facts unchanged.\n"
+            ),
+        }[mode]
         return (
             "System: You are a deterministic translation post-editor.\n"
-            "Rules:\n"
+            "Global rules:\n"
             "1) Keep meaning and scope identical to the draft.\n"
             "2) Do NOT add or remove information.\n"
-            "2b) Edit only [DRAFT_TRANSLATION]; do not rewrite [SOURCE].\n"
-            "3) Preserve every placeholder matching __LT_[A-Z_0-9]+__ exactly, character-for-character.\n"
-            "4) Keep numbers, URLs, code, commands, and identifiers unchanged.\n"
-            "5) Return only the edited segment text, with no commentary, no quotes, and no prefix.\n"
-            "6) If no edits are needed, return the draft unchanged.\n\n"
+            "3) Edit only [DRAFT_TRANSLATION]; do not rewrite [SOURCE].\n"
+            "4) Preserve every placeholder matching __LT_[A-Z_0-9]+__ exactly.\n"
+            "5) Keep numbers, URLs, code, commands, and identifiers unchanged.\n"
+            "6) Keep glossary target terms exactly as written in [GLOSSARY].\n"
+            "7) Return only the edited segment text, with no commentary.\n"
+            f"{mode_rules}\n"
             f"[SOURCE]\n{source}\n[/SOURCE]\n\n"
             f"[DRAFT_TRANSLATION]\n{translated}\n[/DRAFT_TRANSLATION]\n\n"
             f"[GLOSSARY]\n{glossary_lines}\n[/GLOSSARY]\n\n"
             "[OUTPUT]\n"
         )
 
-    def _max_tokens_budget(self, draft: str) -> int:
-        # Limit short-segment latency while keeping headroom on longer drafts.
-        heuristic_budget = int(len(draft) * 0.75) + 16
-        return max(32, min(self.max_tokens, heuristic_budget))
+    def _max_tokens_budget(self, draft: str, mode: PostEditMode) -> int:
+        ratio = 0.55 if mode == "safe" else 0.85
+        heuristic_budget = int(len(draft) * ratio) + 16
+        return max(24, min(self.max_tokens, heuristic_budget))
 
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: PostEditMode = "safe",
+    ) -> str:
         if not translated.strip() or not self.model_path:
             return translated
 
         llm = self._load_model()
-        prompt = self._build_prompt(source, translated, glossary)
-        max_tokens = self._max_tokens_budget(translated)
-        LOGGER.debug("LLM prompt (%d chars): %s", len(prompt), prompt)
+        prompt = self._build_prompt(source, translated, glossary, mode=mode)
+        max_tokens = self._max_tokens_budget(translated, mode)
+        LOGGER.debug("LLM prompt (%d chars, mode=%s)", len(prompt), mode)
         started = time.perf_counter()
         out = llm(
             prompt,
@@ -97,10 +124,10 @@ class LLMEngine:
         )
         candidate = out["choices"][0]["text"].strip()
         LOGGER.debug(
-            "LLM generation completed in %.3fs | max_tokens=%d | output_chars=%d | output=%s",
+            "LLM generation completed in %.3fs | mode=%s | max_tokens=%d | output_chars=%d",
             time.perf_counter() - started,
+            mode,
             max_tokens,
             len(candidate),
-            candidate,
         )
         return candidate

--- a/src/local_translator/models/types.py
+++ b/src/local_translator/models/types.py
@@ -25,4 +25,6 @@ class TranslationReport:
     elapsed_seconds: float
     fallback_count: int = 0
     glossary_replacements: int = 0
+    llm_calls: int = 0
+    llm_skipped: int = 0
     errors: list[str] = field(default_factory=list)

--- a/src/local_translator/pipeline/hybrid_strategy.py
+++ b/src/local_translator/pipeline/hybrid_strategy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from local_translator.config import LLMSettings
+
+PostEditMode = Literal["safe", "smart"]
+
+_PLACEHOLDER_RE = re.compile(r"__LT_[A-Z0-9_]+__")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+@dataclass(slots=True)
+class SegmentFeatures:
+    char_count: int
+    placeholder_count: int
+    technical_token_count: int
+    sentence_count: int
+    glossary_hits: int
+
+    @property
+    def placeholder_ratio(self) -> float:
+        return self.placeholder_count / max(1, self.char_count)
+
+
+@dataclass(slots=True)
+class LLMDecision:
+    use_llm: bool
+    mode: PostEditMode | None = None
+    reason: str = ""
+
+
+def extract_segment_features(segment: str, translated_segment: str, glossary: dict[str, str]) -> SegmentFeatures:
+    char_count = len(translated_segment)
+    placeholder_count = len(_PLACEHOLDER_RE.findall(translated_segment))
+    technical_token_count = sum(token in translated_segment for token in ["http", "`", "${", "{{", "--"])
+    sentence_count = max(1, len([p for p in _SENTENCE_SPLIT_RE.split(translated_segment) if p.strip()]))
+    glossary_hits = sum(1 for term in glossary.values() if term and term in translated_segment)
+    return SegmentFeatures(
+        char_count=char_count,
+        placeholder_count=placeholder_count,
+        technical_token_count=technical_token_count,
+        sentence_count=sentence_count,
+        glossary_hits=glossary_hits,
+    )
+
+
+def decide_llm_postedit(
+    segment: str,
+    translated_segment: str,
+    glossary: dict[str, str],
+    llm_settings: LLMSettings,
+) -> LLMDecision:
+    mode = llm_settings.postedit_mode
+    if mode == "off":
+        return LLMDecision(use_llm=False, reason="mode_off")
+
+    features = extract_segment_features(segment, translated_segment, glossary)
+
+    if features.char_count < llm_settings.skip_short_characters:
+        return LLMDecision(use_llm=False, reason="short_segment")
+
+    if features.placeholder_ratio > llm_settings.skip_high_placeholder_ratio:
+        return LLMDecision(use_llm=False, reason="placeholder_dense")
+
+    if mode in {"safe", "smart"}:
+        return LLMDecision(use_llm=True, mode=mode, reason="forced_mode")
+
+    if features.technical_token_count > 0 or features.placeholder_count >= 2:
+        return LLMDecision(use_llm=True, mode="safe", reason="technical_or_placeholder")
+
+    if features.char_count >= llm_settings.smart_min_chars or features.sentence_count > 1:
+        return LLMDecision(use_llm=True, mode="smart", reason="long_or_multisentence")
+
+    return LLMDecision(use_llm=True, mode="safe", reason="default_safe")
+
+
+@dataclass(slots=True)
+class LLMChunk:
+    start_index: int
+    end_index: int
+    segment_indices: list[int]
+
+
+def build_llm_chunks(segments: list[str], target_chars: int, max_chars: int) -> list[LLMChunk]:
+    """Build conservative contiguous chunks for future chunk-level post-editing.
+
+    This planner is intentionally side-effect free and can be adopted incrementally.
+    """
+    chunks: list[LLMChunk] = []
+    current_indices: list[int] = []
+    current_len = 0
+
+    def flush() -> None:
+        nonlocal current_indices, current_len
+        if not current_indices:
+            return
+        chunks.append(
+            LLMChunk(
+                start_index=current_indices[0],
+                end_index=current_indices[-1],
+                segment_indices=current_indices.copy(),
+            )
+        )
+        current_indices = []
+        current_len = 0
+
+    for idx, segment in enumerate(segments):
+        seg_len = len(segment)
+        if current_indices and (current_len + seg_len > max_chars):
+            flush()
+
+        current_indices.append(idx)
+        current_len += seg_len
+
+        if current_len >= target_chars:
+            flush()
+
+    flush()
+    return chunks

--- a/src/local_translator/pipeline/postedit.py
+++ b/src/local_translator/pipeline/postedit.py
@@ -4,6 +4,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
+from typing import Literal
 
 from local_translator.config import LLMSettings
 from local_translator.engines.llm_engine import LLMEngine
@@ -256,6 +257,7 @@ def post_edit_segment_with_metrics(
     translated_segment: str,
     glossary: Glossary | dict[str, str],
     llm_settings: LLMSettings,
+    mode: Literal["safe", "smart"] = "safe",
 ) -> PostEditOutcome:
     if llm_engine is None:
         return PostEditOutcome(text=translated_segment)
@@ -274,6 +276,7 @@ def post_edit_segment_with_metrics(
             source_protected.text,
             glossary_protected.text,
             glossary=glossary.entries if isinstance(glossary, Glossary) else glossary,
+            mode=mode,
         )
     except Exception:
         LOGGER.warning("LLM post-edit failed; falling back to Argos output.", exc_info=True)
@@ -344,6 +347,7 @@ def post_edit_segment(
     translated_segment: str,
     glossary: Glossary | dict[str, str],
     llm_settings: LLMSettings,
+    mode: Literal["safe", "smart"] = "safe",
 ) -> str:
     return post_edit_segment_with_metrics(
         llm_engine=llm_engine,
@@ -351,4 +355,5 @@ def post_edit_segment(
         translated_segment=translated_segment,
         glossary=glossary,
         llm_settings=llm_settings,
+        mode=mode,
     ).text

--- a/src/local_translator/pipeline/translator.py
+++ b/src/local_translator/pipeline/translator.py
@@ -16,6 +16,7 @@ from local_translator.glossary.store import (
 )
 from local_translator.models.types import EngineMode, TranslationReport
 from local_translator.pipeline.chunker import segment_text
+from local_translator.pipeline.hybrid_strategy import decide_llm_postedit
 from local_translator.pipeline.postedit import post_edit_segment_with_metrics
 
 LOGGER = logging.getLogger(__name__)
@@ -50,6 +51,8 @@ class TranslationPipeline:
         errors: list[str] = []
         fallback_count = 0
         glossary_replacements = 0
+        llm_calls = 0
+        llm_skipped = 0
 
         for idx, segment in enumerate(segments):
             segment_started = time.perf_counter()
@@ -83,16 +86,25 @@ class TranslationPipeline:
 
                 stage_started = time.perf_counter()
                 if self.config.engine_mode in {EngineMode.HYBRID, EngineMode.LLM}:
-                    outcome = post_edit_segment_with_metrics(
-                        self.llm,
-                        segment,
-                        with_glossary,
-                        self.glossary,
-                        self.config.llm,
-                    )
-                    final = outcome.text
-                    fallback_count += int(outcome.fallback_used)
-                    glossary_replacements += outcome.glossary_replacements
+                    glossary_entries = self.glossary.entries if hasattr(self.glossary, "entries") else self.glossary
+                    decision = decide_llm_postedit(segment, with_glossary, glossary_entries, self.config.llm)
+                    if decision.use_llm and decision.mode:
+                        llm_calls += 1
+                        outcome = post_edit_segment_with_metrics(
+                            self.llm,
+                            segment,
+                            with_glossary,
+                            self.glossary,
+                            self.config.llm,
+                            mode=decision.mode,
+                        )
+                        final = outcome.text
+                        fallback_count += int(outcome.fallback_used)
+                        glossary_replacements += outcome.glossary_replacements
+                    else:
+                        llm_skipped += 1
+                        final = with_glossary
+                        LOGGER.debug("Segment %d skipped LLM post-edit (%s)", idx, decision.reason)
                 else:
                     final = with_glossary
                 postedit_elapsed = time.perf_counter() - stage_started
@@ -128,6 +140,8 @@ class TranslationPipeline:
             elapsed_seconds=elapsed,
             fallback_count=fallback_count,
             glossary_replacements=glossary_replacements,
+            llm_calls=llm_calls,
+            llm_skipped=llm_skipped,
             errors=errors,
         )
         return TranslationResult(text=" ".join(outputs), report=report)

--- a/src/local_translator/reporting.py
+++ b/src/local_translator/reporting.py
@@ -13,6 +13,8 @@ def format_report(report: TranslationReport) -> str:
         f"Fallbacks: {report.fallback_count}",
         f"Errors: {len(report.errors)}",
         f"Glossary replacements: {report.glossary_replacements}",
+        f"LLM calls: {report.llm_calls}",
+        f"LLM skipped: {report.llm_skipped}",
         f"Time: {report.elapsed_seconds:.3f}s",
     ]
     return "\n".join(lines)
@@ -28,6 +30,8 @@ def report_to_dict(report: TranslationReport) -> dict[str, object]:
         "errors": report.errors,
         "fallback_count": report.fallback_count,
         "glossary_replacements": report.glossary_replacements,
+        "llm_calls": report.llm_calls,
+        "llm_skipped": report.llm_skipped,
     }
 
 

--- a/tests/integration/test_cli_reporting.py
+++ b/tests/integration/test_cli_reporting.py
@@ -83,3 +83,5 @@ def test_text_report_json_export(tmp_path, monkeypatch):
     assert payload["error_count"] == 0
     assert "fallback_count" in payload
     assert "glossary_replacements" in payload
+    assert "llm_calls" in payload
+    assert "llm_skipped" in payload

--- a/tests/integration/test_pipeline_text.py
+++ b/tests/integration/test_pipeline_text.py
@@ -23,18 +23,36 @@ class FrenchToEnglishArgos:
 
 
 class DummyLLM:
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
         # Tries to rewrite glossary terms; strict placeholder validation should reject this.
         return translated.replace("password", "credential")
 
 
 class RewritingLLM:
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
         return translated.replace("acceptance testing", "recipe").replace("work package", "batch")
 
 
 class FailingLLM:
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
         raise RuntimeError("post-edit failed")
 
 
@@ -56,8 +74,31 @@ class PlaceholderNormalizingArgos:
         )
 
 
+
+
+class ModeAwareLLM:
+    def __init__(self):
+        self.modes: list[str] = []
+
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
+        self.modes.append(mode)
+        return translated
+
+
 class PassthroughLLM:
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
         return translated
 
 
@@ -89,6 +130,7 @@ entries:
         glossary_path=glossary_path,
     )
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", DummyArgos())
     monkeypatch.setattr(pipeline, "llm", DummyLLM())
@@ -117,6 +159,7 @@ entries:
         glossary_path=glossary_path,
     )
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", DummyArgos())
     monkeypatch.setattr(pipeline, "llm", FailingLLM())
@@ -162,6 +205,7 @@ entries:
     )
     cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID, glossary_path=glossary_path)
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", FrenchToEnglishArgos())
     monkeypatch.setattr(pipeline, "llm", RewritingLLM())
@@ -187,6 +231,7 @@ entries:
     )
     cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID, glossary_path=glossary_path)
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", FrenchToEnglishArgos())
     monkeypatch.setattr(pipeline, "llm", FailingLLM())
@@ -236,6 +281,7 @@ entries:
     )
     cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID, glossary_path=glossary_path)
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", PlaceholderNormalizingArgos())
     monkeypatch.setattr(pipeline, "llm", PassthroughLLM())
@@ -263,6 +309,7 @@ entries:
     )
     cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID, glossary_path=glossary_path)
     cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 1
     pipeline = TranslationPipeline(cfg)
     monkeypatch.setattr(pipeline, "argos", PlaceholderNormalizingArgos())
     monkeypatch.setattr(pipeline, "llm", FailingLLM())
@@ -294,3 +341,32 @@ entries:
 
     result = pipeline.translate_text("mise en production puis mise en production")
     assert result.text == "production deployment puis production deployment"
+
+
+def test_pipeline_hybrid_skips_llm_for_short_segments(monkeypatch):
+    cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID)
+    cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 20
+    pipeline = TranslationPipeline(cfg)
+    spy_llm = ModeAwareLLM()
+    monkeypatch.setattr(pipeline, "argos", DummyArgos())
+    monkeypatch.setattr(pipeline, "llm", spy_llm)
+
+    result = pipeline.translate_text("ok")
+    assert spy_llm.modes == []
+    assert result.report.llm_calls == 0
+    assert result.report.llm_skipped == 1
+
+
+def test_pipeline_hybrid_uses_smart_mode_for_long_segments(monkeypatch):
+    cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID)
+    cfg.llm.enabled = True
+    cfg.llm.skip_short_characters = 5
+    cfg.llm.smart_min_chars = 40
+    pipeline = TranslationPipeline(cfg)
+    spy_llm = ModeAwareLLM()
+    monkeypatch.setattr(pipeline, "argos", DummyArgos())
+    monkeypatch.setattr(pipeline, "llm", spy_llm)
+
+    pipeline.translate_text("mot de passe " * 8)
+    assert "smart" in spy_llm.modes

--- a/tests/unit/test_hybrid_strategy.py
+++ b/tests/unit/test_hybrid_strategy.py
@@ -1,0 +1,20 @@
+from local_translator.config import LLMSettings
+from local_translator.pipeline.hybrid_strategy import build_llm_chunks, decide_llm_postedit
+
+
+def test_decide_llm_skips_short_segments_by_default():
+    decision = decide_llm_postedit("Bonjour", "Hello", {}, LLMSettings())
+    assert not decision.use_llm
+    assert decision.reason == "short_segment"
+
+
+def test_decide_llm_selects_smart_for_long_multisentence_text():
+    translated = "This is the first sentence. This is the second sentence with more context and detail."
+    decision = decide_llm_postedit("src", translated, {}, LLMSettings(skip_short_characters=5, smart_min_chars=40))
+    assert decision.use_llm
+    assert decision.mode == "smart"
+
+
+def test_build_llm_chunks_groups_contiguous_segments():
+    chunks = build_llm_chunks(["a" * 30, "b" * 30, "c" * 80], target_chars=60, max_chars=100)
+    assert [(c.start_index, c.end_index) for c in chunks] == [(0, 1), (2, 2)]

--- a/tests/unit/test_postedit.py
+++ b/tests/unit/test_postedit.py
@@ -9,7 +9,13 @@ class FakeLLM:
         self.response = response
         self.error = error
 
-    def post_edit(self, source: str, translated: str, glossary: dict[str, str] | None = None) -> str:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
         if self.error:
             raise self.error
         return self.response

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -18,6 +18,8 @@ def test_format_report_contains_human_readable_metrics():
     assert "Fallbacks: 3" in output
     assert "Errors: 0" in output
     assert "Glossary replacements: 8" in output
+    assert "LLM calls: 0" in output
+    assert "LLM skipped: 0" in output
     assert "Time: 2.345s" in output
 
 
@@ -42,4 +44,6 @@ def test_report_to_dict_contains_expected_keys():
         "errors": ["oops"],
         "fallback_count": 1,
         "glossary_replacements": 4,
+        "llm_calls": 0,
+        "llm_skipped": 0,
     }


### PR DESCRIPTION
### Motivation
- Reduce unnecessary per-segment LLM calls and latency while making post-editing more useful for longer or stylistically-important text.
- Preserve strict glossary/placeholder protection and robust Argos fallback while allowing the LLM to do more meaningful refinements when safe.
- Provide observability to measure LLM impact and prepare for chunk-level post-editing for large documents.

### Description
- Added a hybrid decision layer `pipeline/hybrid_strategy.py` with `decide_llm_postedit(...)` heuristics (segment length, placeholder density, technical-token signals, sentence count, glossary hits) and a conservative `build_llm_chunks(...)` planner for future chunked post-editing.
- Redesigned `engines/llm_engine.py` prompting to support two modes (`safe` and `smart`) and mode-aware token-budgeting to trade latency vs. depth of edits, and kept the original hard rules (no info add/remove, preserve placeholders and glossary targets).
- Threaded a `mode` parameter through `pipeline/postedit.py` and invoked it conditionally from `pipeline/translator.py` using the decision layer, and added per-run counters `llm_calls` and `llm_skipped` to `models/types.py` and `reporting.py` for telemetry.
- Kept strict validation/fallback behavior unchanged; the LLM can be skipped, run in SAFE (conservative) or SMART (fluency) mode; chunk planner is non-invasive (planner added but chunk-level execution not enabled).
- Updated and added tests to cover the decision logic, mode propagation, and reporting schema (`tests/unit/test_hybrid_strategy.py`, adjustments to `tests/integration/test_pipeline_text.py`, `tests/integration/test_cli_reporting.py`, and existing postedit/reporting tests).

### Testing
- Ran the full test collection via `pytest -q`, which failed during collection in this environment due to an unrelated `tests.integration` import resolution issue (test collection error, not related to the changes themselves).
- Executed a targeted test run: `PYTHONPATH=. pytest -q tests/unit/test_postedit.py tests/unit/test_reporting.py tests/unit/test_hybrid_strategy.py tests/integration/test_pipeline_text.py tests/integration/test_cli_reporting.py tests/unit/test_chunker.py`, and these tests passed successfully.
- Added unit tests `tests/unit/test_hybrid_strategy.py` and updated integration tests to assert LLM mode propagation and reporting fields, and those updated tests passed in the targeted run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c980b712dc832bae32c2af6f2b5c14)