### PR TITLE
Add opt-in chunked LLM post-edit execution with strict fallback safety

### DIFF
--- a/src/local_translator/config.py
+++ b/src/local_translator/config.py
@@ -27,6 +27,7 @@ class LLMSettings:
     skip_short_characters: int = 48
     skip_high_placeholder_ratio: float = 0.12
     smart_min_chars: int = 160
+    enable_chunking: bool = False
 
 
 @dataclass(slots=True)

--- a/src/local_translator/engines/llm_engine.py
+++ b/src/local_translator/engines/llm_engine.py
@@ -76,6 +76,12 @@ class LLMEngine:
                 "- You may reorder clauses and tighten wording, but keep scope and facts unchanged.\n"
             ),
         }[mode]
+        chunk_rule = ""
+        if "[SEGMENT_" in translated:
+            chunk_rule = (
+                "8) Preserve all [SEGMENT_i]...[/SEGMENT_i] markers exactly.\n"
+                "9) Return every segment block in the same order with no extra text.\n"
+            )
         return (
             "System: You are a deterministic translation post-editor.\n"
             "Global rules:\n"
@@ -86,6 +92,7 @@ class LLMEngine:
             "5) Keep numbers, URLs, code, commands, and identifiers unchanged.\n"
             "6) Keep glossary target terms exactly as written in [GLOSSARY].\n"
             "7) Return only the edited segment text, with no commentary.\n"
+            f"{chunk_rule}"
             f"{mode_rules}\n"
             f"[SOURCE]\n{source}\n[/SOURCE]\n\n"
             f"[DRAFT_TRANSLATION]\n{translated}\n[/DRAFT_TRANSLATION]\n\n"

--- a/src/local_translator/pipeline/hybrid_strategy.py
+++ b/src/local_translator/pipeline/hybrid_strategy.py
@@ -79,44 +79,67 @@ def decide_llm_postedit(
 
 @dataclass(slots=True)
 class LLMChunk:
-    start_index: int
-    end_index: int
     segment_indices: list[int]
+    source_text: str
+    draft_text: str
+    char_count: int
+    placeholder_density: float
 
 
-def build_llm_chunks(segments: list[str], target_chars: int, max_chars: int) -> list[LLMChunk]:
-    """Build conservative contiguous chunks for future chunk-level post-editing.
-
-    This planner is intentionally side-effect free and can be adopted incrementally.
-    """
+def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> list[LLMChunk]:
+    """Build deterministic, conservative contiguous chunks for LLM post-editing."""
     chunks: list[LLMChunk] = []
     current_indices: list[int] = []
-    current_len = 0
+    current_source: list[str] = []
+    current_draft: list[str] = []
+    current_char_count = 0
+    current_placeholder_count = 0
+    max_segments = 4
+    max_chars = 560
 
     def flush() -> None:
-        nonlocal current_indices, current_len
+        nonlocal current_indices, current_source, current_draft, current_char_count, current_placeholder_count
         if not current_indices:
             return
         chunks.append(
             LLMChunk(
-                start_index=current_indices[0],
-                end_index=current_indices[-1],
                 segment_indices=current_indices.copy(),
+                source_text="\n\n".join(current_source),
+                draft_text="\n\n".join(current_draft),
+                char_count=current_char_count,
+                placeholder_density=current_placeholder_count / max(1, current_char_count),
             )
         )
         current_indices = []
-        current_len = 0
+        current_source = []
+        current_draft = []
+        current_char_count = 0
+        current_placeholder_count = 0
 
-    for idx, segment in enumerate(segments):
-        seg_len = len(segment)
-        if current_indices and (current_len + seg_len > max_chars):
+    for idx, _segment in enumerate(segments):
+        item = metadata[idx]
+        should_merge = bool(item.get("can_chunk", False))
+        if not should_merge:
             flush()
+            continue
 
+        seg_source = str(item.get("source", ""))
+        seg_draft = str(item.get("draft", ""))
+        seg_char_count = len(seg_draft)
+        seg_placeholder_count = int(item.get("placeholder_count", 0))
+        if (
+            current_indices
+            and (
+                len(current_indices) >= max_segments
+                or (current_char_count + seg_char_count) > max_chars
+            )
+        ):
+            flush()
         current_indices.append(idx)
-        current_len += seg_len
-
-        if current_len >= target_chars:
-            flush()
+        current_source.append(seg_source)
+        current_draft.append(seg_draft)
+        current_char_count += seg_char_count
+        current_placeholder_count += seg_placeholder_count
 
     flush()
     return chunks

--- a/src/local_translator/pipeline/postedit.py
+++ b/src/local_translator/pipeline/postedit.py
@@ -36,6 +36,7 @@ _PROTECTED_TOKEN_RE = re.compile(
     flags=re.MULTILINE,
 )
 _ANY_PLACEHOLDER_RE = re.compile(r"__LT_[A-Z0-9_]+__")
+_SEGMENT_BLOCK_RE = re.compile(r"\[SEGMENT_(\d+)\]\n(.*?)\n\[/SEGMENT_\1\]", flags=re.DOTALL)
 
 
 @dataclass(slots=True)
@@ -55,6 +56,7 @@ class PostEditOutcome:
     text: str
     fallback_used: bool = False
     glossary_replacements: int = 0
+    failure_reason: str | None = None
 
 
 class TokenProtector:
@@ -251,6 +253,93 @@ def _log_placeholder_diff(candidate_protected: str, token_map: dict[str, str]) -
     )
 
 
+def format_chunk_payload(
+    segment_indices: list[int],
+    source_segments: list[str],
+    draft_segments: list[str],
+) -> tuple[str, str]:
+    source_parts: list[str] = []
+    draft_parts: list[str] = []
+    for rel_idx, seg_idx in enumerate(segment_indices):
+        source_parts.append(f"[SEGMENT_{rel_idx}]\n{source_segments[seg_idx]}\n[/SEGMENT_{rel_idx}]")
+        draft_parts.append(f"[SEGMENT_{rel_idx}]\n{draft_segments[seg_idx]}\n[/SEGMENT_{rel_idx}]")
+    return "\n\n".join(source_parts), "\n\n".join(draft_parts)
+
+
+def parse_chunk_output(candidate: str, expected_segments: int) -> tuple[list[str] | None, str | None]:
+    blocks = list(_SEGMENT_BLOCK_RE.finditer(candidate))
+    if len(blocks) != expected_segments:
+        return None, "missing_segment"
+
+    consumed: list[str] = []
+    extracted: list[str] = []
+    cursor = 0
+    for expected_idx, block in enumerate(blocks):
+        if int(block.group(1)) != expected_idx:
+            return None, "malformed_markers"
+        interstitial = candidate[cursor : block.start()]
+        if interstitial.strip():
+            return None, "malformed_markers"
+        consumed.append(block.group(0))
+        extracted.append(block.group(2).strip())
+        cursor = block.end()
+    if candidate[cursor:].strip():
+        return None, "malformed_markers"
+    return extracted, None
+
+
+def apply_postedit_candidate(
+    source_segment: str,
+    translated_segment: str,
+    candidate_protected: str,
+    glossary: Glossary | dict[str, str],
+    llm_settings: LLMSettings,
+) -> PostEditOutcome:
+    protector = TokenProtector()
+    glossary_protector = GlossaryProtector()
+    validator = PostEditValidator()
+
+    source_protected = protector.protect(source_segment)
+    translated_protected = protector.protect(translated_segment)
+    glossary_protected = glossary_protector.protect(translated_protected.text, glossary)
+    combined_token_map = {**translated_protected.token_map, **glossary_protected.token_map}
+    canonical_candidate = _canonicalize_candidate_placeholders(candidate_protected, combined_token_map)
+    reinjected_candidate = _reinject_missing_placeholders(canonical_candidate, combined_token_map)
+
+    if llm_settings.strict_validation:
+        validation = validator.validate_protected_output(
+            source_protected=source_protected.text,
+            translated_protected=glossary_protected.text,
+            candidate_protected=reinjected_candidate,
+            token_map=combined_token_map,
+            max_expansion_ratio=llm_settings.max_expansion_ratio,
+        )
+        if not validation.is_valid:
+            if validation.reason in {"placeholder_mismatch", "glossary_placeholder_mismatch"}:
+                _log_placeholder_diff(reinjected_candidate, combined_token_map)
+            if llm_settings.fallback_to_argos:
+                return PostEditOutcome(
+                    text=translated_segment,
+                    fallback_used=True,
+                    failure_reason=validation.reason,
+                )
+            return PostEditOutcome(text=reinjected_candidate, failure_reason=validation.reason)
+
+    restored = protector.restore(reinjected_candidate, translated_protected.token_map)
+    restored = glossary_protector.restore(restored, glossary_protected.token_map)
+    if _PLACEHOLDER_RE.search(restored) or _GLOSSARY_PLACEHOLDER_RE.search(restored):
+        if llm_settings.fallback_to_argos:
+            return PostEditOutcome(
+                text=translated_segment,
+                fallback_used=True,
+                failure_reason="unresolved_placeholders",
+            )
+        return PostEditOutcome(text=restored, failure_reason="unresolved_placeholders")
+
+    rendered, replacements = apply_glossary_with_stats(restored, glossary)
+    return PostEditOutcome(text=rendered, glossary_replacements=replacements)
+
+
 def post_edit_segment_with_metrics(
     llm_engine: LLMEngine | None,
     source_segment: str,
@@ -264,8 +353,6 @@ def post_edit_segment_with_metrics(
 
     protector = TokenProtector()
     glossary_protector = GlossaryProtector()
-    validator = PostEditValidator()
-
     source_protected = protector.protect(source_segment)
     translated_protected = protector.protect(translated_segment)
     glossary_protected = glossary_protector.protect(translated_protected.text, glossary)
@@ -280,65 +367,25 @@ def post_edit_segment_with_metrics(
         )
     except Exception:
         LOGGER.warning("LLM post-edit failed; falling back to Argos output.", exc_info=True)
-        return PostEditOutcome(text=translated_segment, fallback_used=True)
+        return PostEditOutcome(text=translated_segment, fallback_used=True, failure_reason="llm_exception")
     llm_elapsed = time.perf_counter() - llm_started
-    combined_token_map = {**translated_protected.token_map, **glossary_protected.token_map}
-    canonical_candidate = _canonicalize_candidate_placeholders(candidate_protected, combined_token_map)
-    reinjected_candidate = _reinject_missing_placeholders(canonical_candidate, combined_token_map)
-    if canonical_candidate != candidate_protected:
-        LOGGER.debug(
-            "Canonicalized placeholders before validation | raw=%r canonical=%r",
-            candidate_protected[:300],
-            canonical_candidate[:300],
-        )
-    if reinjected_candidate != canonical_candidate:
-        LOGGER.debug(
-            "Reinjected literal tokens as placeholders before validation | canonical=%r reinjected=%r",
-            canonical_candidate[:300],
-            reinjected_candidate[:300],
-        )
-
-    validation_started = time.perf_counter()
-    validation_elapsed = 0.0
-    if llm_settings.strict_validation:
-        validation = validator.validate_protected_output(
-            source_protected=source_protected.text,
-            translated_protected=glossary_protected.text,
-            candidate_protected=reinjected_candidate,
-            token_map=combined_token_map,
-            max_expansion_ratio=llm_settings.max_expansion_ratio,
-        )
-        if not validation.is_valid:
-            LOGGER.warning("LLM post-edit rejected (%s).", validation.reason)
-            if validation.reason in {"placeholder_mismatch", "glossary_placeholder_mismatch"}:
-                _log_placeholder_diff(
-                    reinjected_candidate,
-                    combined_token_map,
-                )
-            if llm_settings.fallback_to_argos:
-                return PostEditOutcome(text=translated_segment, fallback_used=True)
-            return PostEditOutcome(text=reinjected_candidate)
-        validation_elapsed = time.perf_counter() - validation_started
-
-    restore_started = time.perf_counter()
-    restored = protector.restore(reinjected_candidate, translated_protected.token_map)
-    restored = glossary_protector.restore(restored, glossary_protected.token_map)
-    if _PLACEHOLDER_RE.search(restored) or _GLOSSARY_PLACEHOLDER_RE.search(restored):
-        LOGGER.warning("LLM output still contains unresolved placeholders; using Argos output.")
-        if llm_settings.fallback_to_argos:
-            return PostEditOutcome(text=translated_segment, fallback_used=True)
-        return PostEditOutcome(text=restored)
-
-    # Enforce glossary one more time after post-edit for deterministic behavior.
-    rendered, replacements = apply_glossary_with_stats(restored, glossary)
-    restore_elapsed = time.perf_counter() - restore_started
-    LOGGER.debug(
-        "Post-edit timings | llm=%.3fs validate=%.3fs restore=%.3fs",
-        llm_elapsed,
-        validation_elapsed,
-        restore_elapsed,
+    validate_started = time.perf_counter()
+    outcome = apply_postedit_candidate(
+        source_segment=source_segment,
+        translated_segment=translated_segment,
+        candidate_protected=candidate_protected,
+        glossary=glossary,
+        llm_settings=llm_settings,
     )
-    return PostEditOutcome(text=rendered, glossary_replacements=replacements)
+    validate_elapsed = time.perf_counter() - validate_started
+    LOGGER.debug(
+        "Post-edit timings | llm=%.3fs validate+restore=%.3fs fallback=%s reason=%s",
+        llm_elapsed,
+        validate_elapsed,
+        outcome.fallback_used,
+        outcome.failure_reason,
+    )
+    return outcome
 
 
 def post_edit_segment(

--- a/src/local_translator/pipeline/translator.py
+++ b/src/local_translator/pipeline/translator.py
@@ -16,8 +16,13 @@ from local_translator.glossary.store import (
 )
 from local_translator.models.types import EngineMode, TranslationReport
 from local_translator.pipeline.chunker import segment_text
-from local_translator.pipeline.hybrid_strategy import decide_llm_postedit
-from local_translator.pipeline.postedit import post_edit_segment_with_metrics
+from local_translator.pipeline.hybrid_strategy import build_llm_chunks, decide_llm_postedit
+from local_translator.pipeline.postedit import (
+    apply_postedit_candidate,
+    format_chunk_payload,
+    parse_chunk_output,
+    post_edit_segment_with_metrics,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,12 +52,18 @@ class TranslationPipeline:
     def translate_text(self, text: str) -> TranslationResult:
         started = time.perf_counter()
         segments = segment_text(text)
-        outputs: list[str] = []
+        outputs: list[str] = [""] * len(segments)
         errors: list[str] = []
         fallback_count = 0
         glossary_replacements = 0
         llm_calls = 0
         llm_skipped = 0
+        llm_calls_saved = 0
+        prepared_sources: list[str] = []
+        prepared_drafts: list[str] = []
+        glossary_maps: list[dict[str, str]] = []
+        llm_metadata: list[dict[str, object]] = []
+        llm_decisions: list[object] = []
 
         for idx, segment in enumerate(segments):
             segment_started = time.perf_counter()
@@ -83,43 +94,35 @@ class TranslationPipeline:
                     with_glossary, glossary_token_map
                 )
                 glossary_replacements += pre_postedit_restore_replacements
-
-                stage_started = time.perf_counter()
-                if self.config.engine_mode in {EngineMode.HYBRID, EngineMode.LLM}:
-                    glossary_entries = self.glossary.entries if hasattr(self.glossary, "entries") else self.glossary
-                    decision = decide_llm_postedit(segment, with_glossary, glossary_entries, self.config.llm)
-                    if decision.use_llm and decision.mode:
-                        llm_calls += 1
-                        outcome = post_edit_segment_with_metrics(
-                            self.llm,
-                            segment,
-                            with_glossary,
-                            self.glossary,
-                            self.config.llm,
-                            mode=decision.mode,
-                        )
-                        final = outcome.text
-                        fallback_count += int(outcome.fallback_used)
-                        glossary_replacements += outcome.glossary_replacements
-                    else:
-                        llm_skipped += 1
-                        final = with_glossary
-                        LOGGER.debug("Segment %d skipped LLM post-edit (%s)", idx, decision.reason)
-                else:
-                    final = with_glossary
-                postedit_elapsed = time.perf_counter() - stage_started
-
-                stage_started = time.perf_counter()
-                final, post_restore_replacements = restore_glossary_terms_with_stats(final, glossary_token_map)
-                glossary_replacements += post_restore_replacements
-                final, post_replacements = apply_glossary_with_stats(final, self.glossary)
-                glossary_replacements += post_replacements
-                final = normalize_restored_text(final)
-                outputs.append(final)
-                restore_elapsed = time.perf_counter() - stage_started
+                prepared_sources.append(segment)
+                prepared_drafts.append(with_glossary)
+                glossary_maps.append(glossary_token_map)
+                glossary_entries = self.glossary.entries if hasattr(self.glossary, "entries") else self.glossary
+                decision = decide_llm_postedit(segment, with_glossary, glossary_entries, self.config.llm)
+                llm_decisions.append(decision)
+                technical_signal = any(token in with_glossary for token in ["http", "```", "`", "${", "{{", "--"])
+                placeholder_count = with_glossary.count("__LT_")
+                can_chunk = (
+                    decision.use_llm
+                    and bool(decision.mode)
+                    and len(with_glossary) >= self.config.llm.skip_short_characters
+                    and placeholder_count <= 1
+                    and not technical_signal
+                )
+                llm_metadata.append(
+                    {
+                        "source": segment,
+                        "draft": with_glossary,
+                        "mode": decision.mode,
+                        "can_chunk": can_chunk and self.config.llm.enable_chunking,
+                        "placeholder_count": placeholder_count,
+                    }
+                )
+                postedit_elapsed = 0.0
+                restore_elapsed = 0.0
                 segment_elapsed = time.perf_counter() - segment_started
                 LOGGER.debug(
-                    "Segment %d timings | protect=%.3fs argos=%.3fs glossary=%.3fs postedit=%.3fs restore=%.3fs total=%.3fs",
+                    "Segment %d prep timings | protect=%.3fs argos=%.3fs glossary=%.3fs postedit=%.3fs restore=%.3fs total=%.3fs",
                     idx,
                     protect_elapsed,
                     argos_elapsed,
@@ -130,9 +133,123 @@ class TranslationPipeline:
                 )
             except Exception as exc:  # best effort fallback
                 errors.append(str(exc))
-                outputs.append(segment)
+                prepared_sources.append(segment)
+                prepared_drafts.append(segment)
+                glossary_maps.append({})
+                llm_metadata.append({"source": segment, "draft": segment, "mode": None, "can_chunk": False, "placeholder_count": 0})
+                llm_decisions.append(None)
+
+        if self.config.engine_mode in {EngineMode.HYBRID, EngineMode.LLM}:
+            handled = set()
+            if self.config.llm.enable_chunking:
+                chunks = build_llm_chunks(prepared_drafts, llm_metadata)
+                for chunk in chunks:
+                    if len(chunk.segment_indices) <= 1:
+                        continue
+                    mode = llm_metadata[chunk.segment_indices[0]].get("mode")
+                    if not mode:
+                        continue
+                    chunk_started = time.perf_counter()
+                    llm_calls += 1
+                    source_payload, draft_payload = format_chunk_payload(
+                        chunk.segment_indices,
+                        prepared_sources,
+                        prepared_drafts,
+                    )
+                    LOGGER.debug(
+                        "LLM chunk created | segments=%s chars=%d placeholder_density=%.3f mode=%s",
+                        chunk.segment_indices,
+                        chunk.char_count,
+                        chunk.placeholder_density,
+                        mode,
+                    )
+                    try:
+                        raw = self.llm.post_edit(
+                            source_payload,
+                            draft_payload,
+                            glossary=self.glossary.entries if hasattr(self.glossary, "entries") else self.glossary,
+                            mode=mode,
+                        )
+                        parsed, parse_reason = parse_chunk_output(raw, len(chunk.segment_indices))
+                        if parse_reason or parsed is None:
+                            raise ValueError(parse_reason or "chunk_parse_failed")
+                        for rel_idx, seg_idx in enumerate(chunk.segment_indices):
+                            outcome = apply_postedit_candidate(
+                                source_segment=prepared_sources[seg_idx],
+                                translated_segment=prepared_drafts[seg_idx],
+                                candidate_protected=parsed[rel_idx],
+                                glossary=self.glossary,
+                                llm_settings=self.config.llm,
+                            )
+                            if outcome.fallback_used:
+                                raise ValueError(outcome.failure_reason or "chunk_validation_failed")
+                            prepared_drafts[seg_idx] = outcome.text
+                            glossary_replacements += outcome.glossary_replacements
+                            handled.add(seg_idx)
+                        llm_calls_saved += max(0, len(chunk.segment_indices) - 1)
+                        LOGGER.debug(
+                            "LLM chunk success | segments=%s elapsed=%.3fs",
+                            chunk.segment_indices,
+                            time.perf_counter() - chunk_started,
+                        )
+                    except Exception as exc:
+                        LOGGER.warning(
+                            "LLM chunk fallback to per-segment | segments=%s reason=%s elapsed=%.3fs",
+                            chunk.segment_indices,
+                            str(exc),
+                            time.perf_counter() - chunk_started,
+                        )
+                        for seg_idx in chunk.segment_indices:
+                            decision = llm_decisions[seg_idx]
+                            if not decision or not decision.use_llm or not decision.mode:
+                                llm_skipped += 1
+                                continue
+                            llm_calls += 1
+                            outcome = post_edit_segment_with_metrics(
+                                self.llm,
+                                prepared_sources[seg_idx],
+                                prepared_drafts[seg_idx],
+                                self.glossary,
+                                self.config.llm,
+                                mode=decision.mode,
+                            )
+                            prepared_drafts[seg_idx] = outcome.text
+                            fallback_count += int(outcome.fallback_used)
+                            glossary_replacements += outcome.glossary_replacements
+                            handled.add(seg_idx)
+
+            for idx, decision in enumerate(llm_decisions):
+                if idx in handled:
+                    continue
+                if decision and decision.use_llm and decision.mode:
+                    llm_calls += 1
+                    outcome = post_edit_segment_with_metrics(
+                        self.llm,
+                        prepared_sources[idx],
+                        prepared_drafts[idx],
+                        self.glossary,
+                        self.config.llm,
+                        mode=decision.mode,
+                    )
+                    prepared_drafts[idx] = outcome.text
+                    fallback_count += int(outcome.fallback_used)
+                    glossary_replacements += outcome.glossary_replacements
+                else:
+                    llm_skipped += 1
+                    reason = decision.reason if decision else "segment_error"
+                    LOGGER.debug("Segment %d skipped LLM post-edit (%s)", idx, reason)
+
+        for idx, final in enumerate(prepared_drafts):
+            glossary_token_map = glossary_maps[idx]
+            final, post_restore_replacements = restore_glossary_terms_with_stats(final, glossary_token_map)
+            glossary_replacements += post_restore_replacements
+            final, post_replacements = apply_glossary_with_stats(final, self.glossary)
+            glossary_replacements += post_replacements
+            outputs[idx] = normalize_restored_text(final)
 
         elapsed = time.perf_counter() - started
+        if llm_calls_saved:
+            LOGGER.debug("Chunking saved %d LLM calls", llm_calls_saved)
         report = TranslationReport(
             segment_count=len(segments),
             translated_count=len(outputs) - len(errors),

--- a/tests/integration/test_pipeline_text.py
+++ b/tests/integration/test_pipeline_text.py
@@ -102,6 +102,34 @@ class PassthroughLLM:
         return translated
 
 
+class ChunkEchoLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
+        self.calls += 1
+        return translated
+
+
+class ChunkBrokenLLM:
+    def post_edit(
+        self,
+        source: str,
+        translated: str,
+        glossary: dict[str, str] | None = None,
+        mode: str = "safe",
+    ) -> str:
+        if "[SEGMENT_0]" in translated:
+            return "[SEGMENT_0]\nOnly first\n[/SEGMENT_0]"
+        return translated
+
+
 def test_pipeline_argos_mode(monkeypatch):
     cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.ARGOS)
     pipeline = TranslationPipeline(cfg)
@@ -370,3 +398,33 @@ def test_pipeline_hybrid_uses_smart_mode_for_long_segments(monkeypatch):
 
     pipeline.translate_text("mot de passe " * 8)
     assert "smart" in spy_llm.modes
+
+
+def test_pipeline_chunking_merges_three_segments_into_one_llm_call(monkeypatch):
+    cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID)
+    cfg.llm.enabled = True
+    cfg.llm.enable_chunking = True
+    cfg.llm.skip_short_characters = 1
+    pipeline = TranslationPipeline(cfg)
+    spy_llm = ChunkEchoLLM()
+    monkeypatch.setattr(pipeline, "argos", DummyArgos())
+    monkeypatch.setattr(pipeline, "llm", spy_llm)
+
+    result = pipeline.translate_text("a. b. c.")
+    assert result.report.segment_count == 3
+    assert result.report.llm_calls == 1
+    assert spy_llm.calls == 1
+
+
+def test_pipeline_chunking_falls_back_to_per_segment_when_markers_invalid(monkeypatch):
+    cfg = RuntimeConfig(source_lang="fr", target_lang="en", engine_mode=EngineMode.HYBRID)
+    cfg.llm.enabled = True
+    cfg.llm.enable_chunking = True
+    cfg.llm.skip_short_characters = 1
+    pipeline = TranslationPipeline(cfg)
+    monkeypatch.setattr(pipeline, "argos", DummyArgos())
+    monkeypatch.setattr(pipeline, "llm", ChunkBrokenLLM())
+
+    result = pipeline.translate_text("a. b. c.")
+    assert result.report.segment_count == 3
+    assert result.report.llm_calls == 4  # 1 failed chunk call + 3 per-segment fallback calls

--- a/tests/unit/test_hybrid_strategy.py
+++ b/tests/unit/test_hybrid_strategy.py
@@ -16,5 +16,11 @@ def test_decide_llm_selects_smart_for_long_multisentence_text():
 
 
 def test_build_llm_chunks_groups_contiguous_segments():
-    chunks = build_llm_chunks(["a" * 30, "b" * 30, "c" * 80], target_chars=60, max_chars=100)
-    assert [(c.start_index, c.end_index) for c in chunks] == [(0, 1), (2, 2)]
+    segments = ["a" * 30, "b" * 30, "c" * 80]
+    metadata = [
+        {"source": "s1", "draft": segments[0], "can_chunk": True, "placeholder_count": 0},
+        {"source": "s2", "draft": segments[1], "can_chunk": True, "placeholder_count": 0},
+        {"source": "s3", "draft": segments[2], "can_chunk": True, "placeholder_count": 0},
+    ]
+    chunks = build_llm_chunks(segments, metadata)
+    assert [c.segment_indices for c in chunks] == [[0, 1, 2]]

--- a/tests/unit/test_postedit.py
+++ b/tests/unit/test_postedit.py
@@ -1,6 +1,11 @@
 from local_translator.config import LLMSettings, RuntimeConfig
 from local_translator.models.types import EngineMode
-from local_translator.pipeline.postedit import TokenProtector, post_edit_segment
+from local_translator.pipeline.postedit import (
+    TokenProtector,
+    format_chunk_payload,
+    parse_chunk_output,
+    post_edit_segment,
+)
 from local_translator.pipeline.translator import TranslationPipeline
 
 
@@ -203,3 +208,22 @@ def test_post_edit_reinjects_glossary_placeholder_with_whitespace_variation():
         llm_settings=LLMSettings(strict_validation=True, fallback_to_argos=True),
     )
     assert result == draft
+
+
+def test_chunk_payload_round_trip_parsing():
+    source_payload, draft_payload = format_chunk_payload(
+        [0, 1, 2],
+        ["s0", "s1", "s2"],
+        ["d0", "d1", "d2"],
+    )
+    assert "[SEGMENT_0]" in source_payload
+    parsed, reason = parse_chunk_output(draft_payload, 3)
+    assert reason is None
+    assert parsed == ["d0", "d1", "d2"]
+
+
+def test_chunk_output_parsing_detects_missing_segments():
+    malformed = "[SEGMENT_0]\nA\n[/SEGMENT_0]"
+    parsed, reason = parse_chunk_output(malformed, 2)
+    assert parsed is None
+    assert reason == "missing_segment"


### PR DESCRIPTION
### Motivation
- Enable safer, deterministic chunked LLM post-editing to reduce LLM calls and improve context while keeping Argos segmentation unchanged. 
- Keep chunking strictly opt-in via configuration so the existing per-segment pipeline remains the default. 
- Use conservative, easy-to-reason rules (contiguous only, small segment counts/char budget, avoid placeholders/technical segments) to avoid fragile merges. 
- Guarantee safety by falling back to the original per-segment behavior on any parse/validation problem to prevent partial corruption.

### Description
- Add `LLMSettings.enable_chunking: bool` (default `False`) to make chunking opt-in via `config.llm.enable_chunking`. 
- Implement `build_llm_chunks(segments, metadata)` that creates deterministic contiguous `LLMChunk` objects with conservative limits (max 4 segments, ~560 chars, placeholder density tracking) driven by per-segment metadata. 
- Add boundary-safe chunk protocol and utilities: `format_chunk_payload(...)` emits `[SEGMENT_i]...[/SEGMENT_i]` blocks and `parse_chunk_output(...)` enforces strict block structure and ordering. 
- Refactor per-segment validation/restore into `apply_postedit_candidate(...)` to reuse placeholder/glossary safety checks for each segment after chunk-level responses. 
- Integrate chunk execution into `TranslationPipeline.translate_text`: prepare drafts as before, assemble eligible chunks, send chunk payloads to the LLM, parse and validate each returned block, and on any chunk parse/validation failure fall back to per-segment post-edit for that chunk. 
- Extend LLM prompt to instruct the model to preserve segment markers when present, and add logging for chunk creation, execution time, validation/fallback reasons, and estimated LLM calls saved. 
- Add and update tests to cover planner behavior, chunk payload round-trip parsing, successful 3-segment→1-chunk calls, and failure-case fallback to per-segment execution.

### Testing
- Ran `pytest -q tests/unit/test_hybrid_strategy.py tests/unit/test_postedit.py tests/integration/test_pipeline_text.py` and the targeted tests passed. 
- Updated unit tests for `build_llm_chunks` and `parse_chunk_output` and added integration tests `test_pipeline_chunking_merges_three_segments_into_one_llm_call` and `test_pipeline_chunking_falls_back_to_per_segment_when_markers_invalid` which verify chunking and safe fallback behavior. 
- The changes are intentionally incremental and all modified/new tests in the targeted test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9846bca28832b91ca1a5b8a476753)