### PR TITLE
Add deterministic routing & chunk tuning metrics and report-summary CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,36 @@ Use `--report` on `text` and `translate` commands to print a structured executio
 
 Use `--report-json <path>` together with `--report` to export the same metrics as JSON for auditing.
 
+Hybrid reports now include routing/chunk tuning metrics:
+
+- skip/safe/smart segment counts,
+- routing reasons per segment (for example `short_plain_segment`, `technical_token_density`, `multi_sentence_prose`),
+- chunk planning traces (`segment_indices`, merge/boundary reasons, placeholder/char counts),
+- validation failure counters (including placeholder mismatch counters),
+- average LLM latency per segment/chunk and estimated calls saved by chunking.
+
+You can summarize multiple JSON reports with:
+
+```bash
+local-translator report-summary run-a.json run-b.json run-c.json
+```
+
+This gives a lightweight feedback loop for threshold tuning on long documents.
+
+### Heuristic tuning knobs (centralized in `LLMSettings`)
+
+Initial conservative defaults:
+
+- `skip_short_characters=48`
+- `skip_high_placeholder_ratio=0.12`
+- `routing_technical_token_threshold=1`
+- `routing_safe_placeholder_count=2`
+- `routing_multi_sentence_threshold=2`
+- `smart_min_chars=160`
+- `chunk_max_placeholders_per_segment=1`
+- `chunk_max_segments=4`
+- `chunk_max_chars=560`
+
 ## V1 supported formats
 
 - `.txt`: full support

--- a/src/local_translator/api.py
+++ b/src/local_translator/api.py
@@ -42,6 +42,24 @@ class PreviewOutput:
 
 
 def _merge_reports(reports: list[TranslationReport]) -> TranslationReport:
+    segment_latency_total = sum(item.avg_llm_latency_per_segment * max(1, item.llm_calls) for item in reports)
+    chunk_latency_total = sum(item.avg_llm_latency_per_chunk * max(1, item.llm_chunks_built) for item in reports)
+    llm_calls_total = sum(item.llm_calls for item in reports)
+    chunk_total = sum(item.llm_chunks_built for item in reports)
+    validation_failures: dict[str, int] = {}
+    routing_reasons: dict[str, int] = {}
+    chunk_boundary_reasons: dict[str, int] = {}
+    chunk_merge_reasons: dict[str, int] = {}
+    for item in reports:
+        for key, value in item.validation_failures.items():
+            validation_failures[key] = validation_failures.get(key, 0) + value
+        for key, value in item.routing_reasons.items():
+            routing_reasons[key] = routing_reasons.get(key, 0) + value
+        for key, value in item.chunk_boundary_reasons.items():
+            chunk_boundary_reasons[key] = chunk_boundary_reasons.get(key, 0) + value
+        for key, value in item.chunk_merge_reasons.items():
+            chunk_merge_reasons[key] = chunk_merge_reasons.get(key, 0) + value
+
     return TranslationReport(
         segment_count=sum(item.segment_count for item in reports),
         translated_count=sum(item.translated_count for item in reports),
@@ -49,7 +67,27 @@ def _merge_reports(reports: list[TranslationReport]) -> TranslationReport:
         elapsed_seconds=sum(item.elapsed_seconds for item in reports),
         fallback_count=sum(item.fallback_count for item in reports),
         glossary_replacements=sum(item.glossary_replacements for item in reports),
+        llm_calls=llm_calls_total,
+        llm_skipped=sum(item.llm_skipped for item in reports),
         errors=[error for item in reports for error in item.errors],
+        llm_safe_segments=sum(item.llm_safe_segments for item in reports),
+        llm_smart_segments=sum(item.llm_smart_segments for item in reports),
+        llm_chunks_built=chunk_total,
+        chunk_fallbacks=sum(item.chunk_fallbacks for item in reports),
+        segment_fallbacks=sum(item.segment_fallbacks for item in reports),
+        avg_chunk_size=(sum(item.avg_chunk_size * item.llm_chunks_built for item in reports) / chunk_total) if chunk_total else 0.0,
+        max_chunk_size=max([item.max_chunk_size for item in reports], default=0),
+        avg_llm_latency_per_segment=(segment_latency_total / llm_calls_total) if llm_calls_total else 0.0,
+        avg_llm_latency_per_chunk=(chunk_latency_total / chunk_total) if chunk_total else 0.0,
+        llm_calls_saved_by_chunking=sum(item.llm_calls_saved_by_chunking for item in reports),
+        validation_failures=validation_failures,
+        placeholder_mismatch_count=sum(item.placeholder_mismatch_count for item in reports),
+        glossary_placeholder_mismatch_count=sum(item.glossary_placeholder_mismatch_count for item in reports),
+        routing_reasons=routing_reasons,
+        chunk_boundary_reasons=chunk_boundary_reasons,
+        chunk_merge_reasons=chunk_merge_reasons,
+        routing_trace=[trace for item in reports for trace in item.routing_trace],
+        chunk_trace=[trace for item in reports for trace in item.chunk_trace],
     )
 
 

--- a/src/local_translator/cli.py
+++ b/src/local_translator/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import typer
@@ -15,7 +16,7 @@ from local_translator.api import (
 )
 from local_translator.gui.stub import run_gui_stub
 from local_translator.logging_utils import setup_logging
-from local_translator.reporting import format_report
+from local_translator.reporting import format_report, summarize_reports
 
 LANG_HELP = (
     "Language code. Supported values: "
@@ -194,6 +195,18 @@ def preview(
 @app.command(help="Open the GUI placeholder (stub).")
 def gui():
     run_gui_stub()
+
+
+@app.command("report-summary", help="Summarize one or more JSON execution reports.")
+def report_summary(
+    report_paths: list[Path] = typer.Argument(..., help="One or more report JSON files."),
+):
+    payloads = []
+    for report_path in report_paths:
+        raw = report_path.read_text(encoding="utf-8")
+        payloads.append(json.loads(raw))
+    summary = summarize_reports(payloads)
+    typer.echo(json.dumps(summary, indent=2, ensure_ascii=False))
 
 
 if __name__ == "__main__":

--- a/src/local_translator/config.py
+++ b/src/local_translator/config.py
@@ -28,6 +28,13 @@ class LLMSettings:
     skip_high_placeholder_ratio: float = 0.12
     smart_min_chars: int = 160
     enable_chunking: bool = False
+    routing_technical_token_threshold: int = 1
+    routing_safe_placeholder_count: int = 2
+    routing_multi_sentence_threshold: int = 2
+    chunk_max_placeholders_per_segment: int = 1
+    chunk_max_segments: int = 4
+    chunk_max_chars: int = 560
+    chunk_min_chars_for_merge: int = 1
 
 
 @dataclass(slots=True)

--- a/src/local_translator/models/types.py
+++ b/src/local_translator/models/types.py
@@ -28,3 +28,21 @@ class TranslationReport:
     llm_calls: int = 0
     llm_skipped: int = 0
     errors: list[str] = field(default_factory=list)
+    llm_safe_segments: int = 0
+    llm_smart_segments: int = 0
+    llm_chunks_built: int = 0
+    chunk_fallbacks: int = 0
+    segment_fallbacks: int = 0
+    avg_chunk_size: float = 0.0
+    max_chunk_size: int = 0
+    avg_llm_latency_per_segment: float = 0.0
+    avg_llm_latency_per_chunk: float = 0.0
+    llm_calls_saved_by_chunking: int = 0
+    validation_failures: dict[str, int] = field(default_factory=dict)
+    placeholder_mismatch_count: int = 0
+    glossary_placeholder_mismatch_count: int = 0
+    routing_reasons: dict[str, int] = field(default_factory=dict)
+    chunk_boundary_reasons: dict[str, int] = field(default_factory=dict)
+    chunk_merge_reasons: dict[str, int] = field(default_factory=dict)
+    routing_trace: list[dict[str, object]] = field(default_factory=list)
+    chunk_trace: list[dict[str, object]] = field(default_factory=list)

--- a/src/local_translator/pipeline/hybrid_strategy.py
+++ b/src/local_translator/pipeline/hybrid_strategy.py
@@ -32,6 +32,18 @@ class LLMDecision:
     reason: str = ""
 
 
+@dataclass(slots=True)
+class LLMChunk:
+    segment_indices: list[int]
+    source_text: str
+    draft_text: str
+    char_count: int
+    placeholder_density: float
+    mode: PostEditMode | None
+    merge_reason: str
+    boundary_reason: str | None = None
+
+
 def extract_segment_features(segment: str, translated_segment: str, glossary: dict[str, str]) -> SegmentFeatures:
     char_count = len(translated_segment)
     placeholder_count = len(_PLACEHOLDER_RE.findall(translated_segment))
@@ -60,33 +72,30 @@ def decide_llm_postedit(
     features = extract_segment_features(segment, translated_segment, glossary)
 
     if features.char_count < llm_settings.skip_short_characters:
-        return LLMDecision(use_llm=False, reason="short_segment")
+        return LLMDecision(use_llm=False, reason="short_plain_segment")
 
     if features.placeholder_ratio > llm_settings.skip_high_placeholder_ratio:
-        return LLMDecision(use_llm=False, reason="placeholder_dense")
+        return LLMDecision(use_llm=False, reason="high_placeholder_density")
 
     if mode in {"safe", "smart"}:
         return LLMDecision(use_llm=True, mode=mode, reason="forced_mode")
 
-    if features.technical_token_count > 0 or features.placeholder_count >= 2:
-        return LLMDecision(use_llm=True, mode="safe", reason="technical_or_placeholder")
+    if features.technical_token_count >= llm_settings.routing_technical_token_threshold:
+        return LLMDecision(use_llm=True, mode="safe", reason="technical_token_density")
 
-    if features.char_count >= llm_settings.smart_min_chars or features.sentence_count > 1:
-        return LLMDecision(use_llm=True, mode="smart", reason="long_or_multisentence")
+    if features.placeholder_count >= llm_settings.routing_safe_placeholder_count:
+        return LLMDecision(use_llm=True, mode="safe", reason="high_placeholder_density")
+
+    if features.sentence_count >= llm_settings.routing_multi_sentence_threshold:
+        return LLMDecision(use_llm=True, mode="smart", reason="multi_sentence_prose")
+
+    if features.char_count >= llm_settings.smart_min_chars:
+        return LLMDecision(use_llm=True, mode="smart", reason="long_natural_language_segment")
 
     return LLMDecision(use_llm=True, mode="safe", reason="default_safe")
 
 
-@dataclass(slots=True)
-class LLMChunk:
-    segment_indices: list[int]
-    source_text: str
-    draft_text: str
-    char_count: int
-    placeholder_density: float
-
-
-def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> list[LLMChunk]:
+def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]], llm_settings: LLMSettings) -> list[LLMChunk]:
     """Build deterministic, conservative contiguous chunks for LLM post-editing."""
     chunks: list[LLMChunk] = []
     current_indices: list[int] = []
@@ -94,13 +103,13 @@ def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> 
     current_draft: list[str] = []
     current_char_count = 0
     current_placeholder_count = 0
-    max_segments = 4
-    max_chars = 560
+    boundary_reason: str | None = None
 
     def flush() -> None:
-        nonlocal current_indices, current_source, current_draft, current_char_count, current_placeholder_count
+        nonlocal current_indices, current_source, current_draft, current_char_count, current_placeholder_count, boundary_reason
         if not current_indices:
             return
+        first_mode = metadata[current_indices[0]].get("mode") if current_indices else None
         chunks.append(
             LLMChunk(
                 segment_indices=current_indices.copy(),
@@ -108,6 +117,9 @@ def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> 
                 draft_text="\n\n".join(current_draft),
                 char_count=current_char_count,
                 placeholder_density=current_placeholder_count / max(1, current_char_count),
+                mode=first_mode if isinstance(first_mode, str) else None,
+                merge_reason="merged_consecutive_prose_segments",
+                boundary_reason=boundary_reason,
             )
         )
         current_indices = []
@@ -115,11 +127,13 @@ def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> 
         current_draft = []
         current_char_count = 0
         current_placeholder_count = 0
+        boundary_reason = None
 
     for idx, _segment in enumerate(segments):
         item = metadata[idx]
         should_merge = bool(item.get("can_chunk", False))
         if not should_merge:
+            boundary_reason = "stopped_due_to_mode_change"
             flush()
             continue
 
@@ -130,10 +144,15 @@ def build_llm_chunks(segments: list[str], metadata: list[dict[str, object]]) -> 
         if (
             current_indices
             and (
-                len(current_indices) >= max_segments
-                or (current_char_count + seg_char_count) > max_chars
+                len(current_indices) >= llm_settings.chunk_max_segments
+                or (current_char_count + seg_char_count) > llm_settings.chunk_max_chars
             )
         ):
+            boundary_reason = (
+                "stopped_due_to_max_segments"
+                if len(current_indices) >= llm_settings.chunk_max_segments
+                else "stopped_due_to_max_chars"
+            )
             flush()
         current_indices.append(idx)
         current_source.append(seg_source)

--- a/src/local_translator/pipeline/postedit.py
+++ b/src/local_translator/pipeline/postedit.py
@@ -57,6 +57,7 @@ class PostEditOutcome:
     fallback_used: bool = False
     glossary_replacements: int = 0
     failure_reason: str | None = None
+    llm_latency_seconds: float = 0.0
 
 
 class TokenProtector:
@@ -367,7 +368,12 @@ def post_edit_segment_with_metrics(
         )
     except Exception:
         LOGGER.warning("LLM post-edit failed; falling back to Argos output.", exc_info=True)
-        return PostEditOutcome(text=translated_segment, fallback_used=True, failure_reason="llm_exception")
+        return PostEditOutcome(
+            text=translated_segment,
+            fallback_used=True,
+            failure_reason="llm_exception",
+            llm_latency_seconds=time.perf_counter() - llm_started,
+        )
     llm_elapsed = time.perf_counter() - llm_started
     validate_started = time.perf_counter()
     outcome = apply_postedit_candidate(
@@ -385,6 +391,7 @@ def post_edit_segment_with_metrics(
         outcome.fallback_used,
         outcome.failure_reason,
     )
+    outcome.llm_latency_seconds = llm_elapsed
     return outcome
 
 

--- a/src/local_translator/pipeline/translator.py
+++ b/src/local_translator/pipeline/translator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import Counter
 from dataclasses import dataclass
 
 from local_translator.config import RuntimeConfig
@@ -59,6 +60,20 @@ class TranslationPipeline:
         llm_calls = 0
         llm_skipped = 0
         llm_calls_saved = 0
+        llm_safe_segments = 0
+        llm_smart_segments = 0
+        llm_segment_latencies: list[float] = []
+        llm_chunk_latencies: list[float] = []
+        chunk_sizes: list[int] = []
+        chunk_fallbacks = 0
+        segment_fallbacks = 0
+        validation_failures: Counter[str] = Counter()
+        routing_reasons: Counter[str] = Counter()
+        chunk_boundary_reasons: Counter[str] = Counter()
+        chunk_merge_reasons: Counter[str] = Counter()
+        routing_trace: list[dict[str, object]] = []
+        chunk_trace: list[dict[str, object]] = []
+
         prepared_sources: list[str] = []
         prepared_drafts: list[str] = []
         glossary_maps: list[dict[str, str]] = []
@@ -87,9 +102,6 @@ class TranslationPipeline:
                 glossary_replacements += replacements
                 glossary_elapsed = time.perf_counter() - stage_started
 
-                # Normalize Argos-normalized glossary placeholders (e.g. "LT GLOSSARY TERM 0000")
-                # back to canonical target terms before LLM post-editing. This avoids turning
-                # these artifacts into fragmented protected tokens during strict validation.
                 with_glossary, pre_postedit_restore_replacements = restore_glossary_terms_with_stats(
                     with_glossary, glossary_token_map
                 )
@@ -100,35 +112,47 @@ class TranslationPipeline:
                 glossary_entries = self.glossary.entries if hasattr(self.glossary, "entries") else self.glossary
                 decision = decide_llm_postedit(segment, with_glossary, glossary_entries, self.config.llm)
                 llm_decisions.append(decision)
+                routing_reasons[decision.reason] += 1
+                routing_trace.append(
+                    {
+                        "segment_index": idx,
+                        "mode": decision.mode if decision.use_llm else "skip",
+                        "reason": decision.reason,
+                        "char_count": len(with_glossary),
+                        "placeholder_count": with_glossary.count("__LT_"),
+                    }
+                )
+                if decision.mode == "safe":
+                    llm_safe_segments += 1
+                elif decision.mode == "smart":
+                    llm_smart_segments += 1
+
                 technical_signal = any(token in with_glossary for token in ["http", "```", "`", "${", "{{", "--"])
                 placeholder_count = with_glossary.count("__LT_")
                 can_chunk = (
                     decision.use_llm
                     and bool(decision.mode)
-                    and len(with_glossary) >= self.config.llm.skip_short_characters
-                    and placeholder_count <= 1
+                    and len(with_glossary) >= self.config.llm.chunk_min_chars_for_merge
+                    and placeholder_count <= self.config.llm.chunk_max_placeholders_per_segment
                     and not technical_signal
+                    and self.config.llm.enable_chunking
                 )
                 llm_metadata.append(
                     {
                         "source": segment,
                         "draft": with_glossary,
                         "mode": decision.mode,
-                        "can_chunk": can_chunk and self.config.llm.enable_chunking,
+                        "can_chunk": can_chunk,
                         "placeholder_count": placeholder_count,
                     }
                 )
-                postedit_elapsed = 0.0
-                restore_elapsed = 0.0
                 segment_elapsed = time.perf_counter() - segment_started
                 LOGGER.debug(
-                    "Segment %d prep timings | protect=%.3fs argos=%.3fs glossary=%.3fs postedit=%.3fs restore=%.3fs total=%.3fs",
+                    "Segment %d prep timings | protect=%.3fs argos=%.3fs glossary=%.3fs total=%.3fs",
                     idx,
                     protect_elapsed,
                     argos_elapsed,
                     glossary_elapsed,
-                    postedit_elapsed,
-                    restore_elapsed,
                     segment_elapsed,
                 )
             except Exception as exc:  # best effort fallback
@@ -138,30 +162,39 @@ class TranslationPipeline:
                 glossary_maps.append({})
                 llm_metadata.append({"source": segment, "draft": segment, "mode": None, "can_chunk": False, "placeholder_count": 0})
                 llm_decisions.append(None)
+                routing_reasons["segment_error"] += 1
+                routing_trace.append({"segment_index": idx, "mode": "skip", "reason": "segment_error", "char_count": len(segment), "placeholder_count": 0})
 
         if self.config.engine_mode in {EngineMode.HYBRID, EngineMode.LLM}:
             handled = set()
             if self.config.llm.enable_chunking:
-                chunks = build_llm_chunks(prepared_drafts, llm_metadata)
+                chunks = build_llm_chunks(prepared_drafts, llm_metadata, self.config.llm)
                 for chunk in chunks:
                     if len(chunk.segment_indices) <= 1:
                         continue
                     mode = llm_metadata[chunk.segment_indices[0]].get("mode")
                     if not mode:
                         continue
+                    chunk_sizes.append(len(chunk.segment_indices))
+                    chunk_merge_reasons[chunk.merge_reason] += 1
+                    if chunk.boundary_reason:
+                        chunk_boundary_reasons[chunk.boundary_reason] += 1
+                    chunk_trace.append(
+                        {
+                            "segment_indices": chunk.segment_indices,
+                            "routing_mode": mode,
+                            "character_count": chunk.char_count,
+                            "placeholder_count": sum(int(llm_metadata[i].get("placeholder_count", 0)) for i in chunk.segment_indices),
+                            "merge_reason": chunk.merge_reason,
+                            "boundary_reason": chunk.boundary_reason,
+                        }
+                    )
                     chunk_started = time.perf_counter()
                     llm_calls += 1
                     source_payload, draft_payload = format_chunk_payload(
                         chunk.segment_indices,
                         prepared_sources,
                         prepared_drafts,
-                    )
-                    LOGGER.debug(
-                        "LLM chunk created | segments=%s chars=%d placeholder_density=%.3f mode=%s",
-                        chunk.segment_indices,
-                        chunk.char_count,
-                        chunk.placeholder_density,
-                        mode,
                     )
                     try:
                         raw = self.llm.post_edit(
@@ -172,6 +205,7 @@ class TranslationPipeline:
                         )
                         parsed, parse_reason = parse_chunk_output(raw, len(chunk.segment_indices))
                         if parse_reason or parsed is None:
+                            validation_failures[parse_reason or "chunk_parse_failed"] += 1
                             raise ValueError(parse_reason or "chunk_parse_failed")
                         for rel_idx, seg_idx in enumerate(chunk.segment_indices):
                             outcome = apply_postedit_candidate(
@@ -182,22 +216,20 @@ class TranslationPipeline:
                                 llm_settings=self.config.llm,
                             )
                             if outcome.fallback_used:
+                                validation_failures[outcome.failure_reason or "chunk_validation_failed"] += 1
                                 raise ValueError(outcome.failure_reason or "chunk_validation_failed")
                             prepared_drafts[seg_idx] = outcome.text
                             glossary_replacements += outcome.glossary_replacements
                             handled.add(seg_idx)
                         llm_calls_saved += max(0, len(chunk.segment_indices) - 1)
-                        LOGGER.debug(
-                            "LLM chunk success | segments=%s elapsed=%.3fs",
-                            chunk.segment_indices,
-                            time.perf_counter() - chunk_started,
-                        )
+                        llm_chunk_latencies.append(time.perf_counter() - chunk_started)
                     except Exception as exc:
+                        chunk_fallbacks += 1
+                        llm_chunk_latencies.append(time.perf_counter() - chunk_started)
                         LOGGER.warning(
-                            "LLM chunk fallback to per-segment | segments=%s reason=%s elapsed=%.3fs",
+                            "LLM chunk fallback to per-segment | segments=%s reason=%s",
                             chunk.segment_indices,
                             str(exc),
-                            time.perf_counter() - chunk_started,
                         )
                         for seg_idx in chunk.segment_indices:
                             decision = llm_decisions[seg_idx]
@@ -213,9 +245,13 @@ class TranslationPipeline:
                                 self.config.llm,
                                 mode=decision.mode,
                             )
+                            llm_segment_latencies.append(outcome.llm_latency_seconds)
                             prepared_drafts[seg_idx] = outcome.text
                             fallback_count += int(outcome.fallback_used)
+                            segment_fallbacks += int(outcome.fallback_used)
                             glossary_replacements += outcome.glossary_replacements
+                            if outcome.failure_reason:
+                                validation_failures[outcome.failure_reason] += 1
                             handled.add(seg_idx)
 
             for idx, decision in enumerate(llm_decisions):
@@ -231,9 +267,13 @@ class TranslationPipeline:
                         self.config.llm,
                         mode=decision.mode,
                     )
+                    llm_segment_latencies.append(outcome.llm_latency_seconds)
                     prepared_drafts[idx] = outcome.text
                     fallback_count += int(outcome.fallback_used)
+                    segment_fallbacks += int(outcome.fallback_used)
                     glossary_replacements += outcome.glossary_replacements
+                    if outcome.failure_reason:
+                        validation_failures[outcome.failure_reason] += 1
                 else:
                     llm_skipped += 1
                     reason = decision.reason if decision else "segment_error"
@@ -248,8 +288,6 @@ class TranslationPipeline:
             outputs[idx] = normalize_restored_text(final)
 
         elapsed = time.perf_counter() - started
-        if llm_calls_saved:
-            LOGGER.debug("Chunking saved %d LLM calls", llm_calls_saved)
         report = TranslationReport(
             segment_count=len(segments),
             translated_count=len(outputs) - len(errors),
@@ -260,5 +298,23 @@ class TranslationPipeline:
             llm_calls=llm_calls,
             llm_skipped=llm_skipped,
             errors=errors,
+            llm_safe_segments=llm_safe_segments,
+            llm_smart_segments=llm_smart_segments,
+            llm_chunks_built=len(chunk_sizes),
+            chunk_fallbacks=chunk_fallbacks,
+            segment_fallbacks=segment_fallbacks,
+            avg_chunk_size=(sum(chunk_sizes) / len(chunk_sizes)) if chunk_sizes else 0.0,
+            max_chunk_size=max(chunk_sizes) if chunk_sizes else 0,
+            avg_llm_latency_per_segment=(sum(llm_segment_latencies) / len(llm_segment_latencies)) if llm_segment_latencies else 0.0,
+            avg_llm_latency_per_chunk=(sum(llm_chunk_latencies) / len(llm_chunk_latencies)) if llm_chunk_latencies else 0.0,
+            llm_calls_saved_by_chunking=llm_calls_saved,
+            validation_failures=dict(validation_failures),
+            placeholder_mismatch_count=validation_failures.get("placeholder_mismatch", 0),
+            glossary_placeholder_mismatch_count=validation_failures.get("glossary_placeholder_mismatch", 0),
+            routing_reasons=dict(routing_reasons),
+            chunk_boundary_reasons=dict(chunk_boundary_reasons),
+            chunk_merge_reasons=dict(chunk_merge_reasons),
+            routing_trace=routing_trace,
+            chunk_trace=chunk_trace,
         )
         return TranslationResult(text=" ".join(outputs), report=report)

--- a/src/local_translator/reporting.py
+++ b/src/local_translator/reporting.py
@@ -10,11 +10,22 @@ def format_report(report: TranslationReport) -> str:
     lines = [
         "Execution report",
         f"Segments processed: {report.segment_count}",
+        f"LLM skipped: {report.llm_skipped}",
+        f"SAFE segments: {report.llm_safe_segments}",
+        f"SMART segments: {report.llm_smart_segments}",
+        f"LLM calls: {report.llm_calls}",
+        f"Chunks built: {report.llm_chunks_built} (avg size={report.avg_chunk_size:.2f}, max size={report.max_chunk_size})",
+        f"Chunk fallbacks: {report.chunk_fallbacks}",
+        f"Segment fallbacks: {report.segment_fallbacks}",
         f"Fallbacks: {report.fallback_count}",
+        f"Validation failures: {report.validation_failures}",
+        f"Placeholder mismatches: {report.placeholder_mismatch_count}",
+        f"Glossary placeholder mismatches: {report.glossary_placeholder_mismatch_count}",
+        f"Avg LLM latency per segment: {report.avg_llm_latency_per_segment:.3f}s",
+        f"Avg LLM latency per chunk: {report.avg_llm_latency_per_chunk:.3f}s",
+        f"Estimated calls saved by chunking: {report.llm_calls_saved_by_chunking}",
         f"Errors: {len(report.errors)}",
         f"Glossary replacements: {report.glossary_replacements}",
-        f"LLM calls: {report.llm_calls}",
-        f"LLM skipped: {report.llm_skipped}",
         f"Time: {report.elapsed_seconds:.3f}s",
     ]
     return "\n".join(lines)
@@ -32,6 +43,59 @@ def report_to_dict(report: TranslationReport) -> dict[str, object]:
         "glossary_replacements": report.glossary_replacements,
         "llm_calls": report.llm_calls,
         "llm_skipped": report.llm_skipped,
+        "llm_safe_segments": report.llm_safe_segments,
+        "llm_smart_segments": report.llm_smart_segments,
+        "llm_chunks_built": report.llm_chunks_built,
+        "avg_chunk_size": round(report.avg_chunk_size, 3),
+        "max_chunk_size": report.max_chunk_size,
+        "chunk_fallbacks": report.chunk_fallbacks,
+        "segment_fallbacks": report.segment_fallbacks,
+        "avg_llm_latency_per_segment": round(report.avg_llm_latency_per_segment, 6),
+        "avg_llm_latency_per_chunk": round(report.avg_llm_latency_per_chunk, 6),
+        "llm_calls_saved_by_chunking": report.llm_calls_saved_by_chunking,
+        "validation_failures": report.validation_failures,
+        "placeholder_mismatch_count": report.placeholder_mismatch_count,
+        "glossary_placeholder_mismatch_count": report.glossary_placeholder_mismatch_count,
+        "routing_reasons": report.routing_reasons,
+        "chunk_boundary_reasons": report.chunk_boundary_reasons,
+        "chunk_merge_reasons": report.chunk_merge_reasons,
+        "routing_trace": report.routing_trace,
+        "chunk_trace": report.chunk_trace,
+    }
+
+
+def summarize_reports(report_payloads: list[dict[str, object]]) -> dict[str, object]:
+    total_segments = sum(int(item.get("segment_count", 0)) for item in report_payloads)
+    total_llm_skipped = sum(int(item.get("llm_skipped", 0)) for item in report_payloads)
+    total_safe = sum(int(item.get("llm_safe_segments", 0)) for item in report_payloads)
+    total_smart = sum(int(item.get("llm_smart_segments", 0)) for item in report_payloads)
+    total_chunk_fallbacks = sum(int(item.get("chunk_fallbacks", 0)) for item in report_payloads)
+    total_segment_fallbacks = sum(int(item.get("segment_fallbacks", 0)) for item in report_payloads)
+    total_saved = sum(int(item.get("llm_calls_saved_by_chunking", 0)) for item in report_payloads)
+    avg_chunk = 0.0
+    total_chunks = sum(int(item.get("llm_chunks_built", 0)) for item in report_payloads)
+    if total_chunks:
+        weighted = sum(float(item.get("avg_chunk_size", 0.0)) * int(item.get("llm_chunks_built", 0)) for item in report_payloads)
+        avg_chunk = weighted / total_chunks
+
+    validation_failures: dict[str, int] = {}
+    for item in report_payloads:
+        failures = item.get("validation_failures", {})
+        if isinstance(failures, dict):
+            for key, value in failures.items():
+                validation_failures[str(key)] = validation_failures.get(str(key), 0) + int(value)
+
+    return {
+        "reports": len(report_payloads),
+        "segments": total_segments,
+        "llm_skip_rate": round(total_llm_skipped / max(1, total_segments), 4),
+        "safe_share": round(total_safe / max(1, total_segments), 4),
+        "smart_share": round(total_smart / max(1, total_segments), 4),
+        "chunk_fallbacks": total_chunk_fallbacks,
+        "segment_fallbacks": total_segment_fallbacks,
+        "avg_chunk_size": round(avg_chunk, 3),
+        "llm_calls_saved_by_chunking": total_saved,
+        "validation_failures": dict(sorted(validation_failures.items(), key=lambda kv: (-kv[1], kv[0]))),
     }
 
 

--- a/tests/integration/test_cli_reporting.py
+++ b/tests/integration/test_cli_reporting.py
@@ -85,3 +85,50 @@ def test_text_report_json_export(tmp_path, monkeypatch):
     assert "glossary_replacements" in payload
     assert "llm_calls" in payload
     assert "llm_skipped" in payload
+    assert "validation_failures" in payload
+    assert "routing_trace" in payload
+
+
+def test_report_summary_command(tmp_path):
+    report_a = tmp_path / "a.json"
+    report_b = tmp_path / "b.json"
+    report_a.write_text(
+        json.dumps(
+            {
+                "segment_count": 10,
+                "llm_skipped": 7,
+                "llm_safe_segments": 2,
+                "llm_smart_segments": 1,
+                "llm_chunks_built": 1,
+                "avg_chunk_size": 3.0,
+                "chunk_fallbacks": 0,
+                "segment_fallbacks": 1,
+                "llm_calls_saved_by_chunking": 2,
+                "validation_failures": {"placeholder_mismatch": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+    report_b.write_text(
+        json.dumps(
+            {
+                "segment_count": 10,
+                "llm_skipped": 6,
+                "llm_safe_segments": 3,
+                "llm_smart_segments": 1,
+                "llm_chunks_built": 2,
+                "avg_chunk_size": 2.0,
+                "chunk_fallbacks": 1,
+                "segment_fallbacks": 1,
+                "llm_calls_saved_by_chunking": 1,
+                "validation_failures": {"placeholder_mismatch": 2},
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["report-summary", str(report_a), str(report_b)])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["segments"] == 20
+    assert payload["llm_calls_saved_by_chunking"] == 3
+    assert payload["validation_failures"]["placeholder_mismatch"] == 3


### PR DESCRIPTION
### Motivation
- Provide a deterministic, local, rule-based tuning layer so routing and chunking heuristics can be evaluated and adjusted from real runs without ML or runtime learning.
- Capture structured metrics and traces to answer whether LLM post-editing is helpful, where to skip, chunk, or tighten thresholds, and where fallbacks occur.
- Keep behavior explicit, inspectable, and fallback-safe while giving a lightweight feedback loop for long-document runs.

### Description
- Centralized routing and chunk heuristics in `LLMSettings` with easy-to-tune knobs such as `skip_short_characters`, `skip_high_placeholder_ratio`, `routing_technical_token_threshold`, `routing_safe_placeholder_count`, `routing_multi_sentence_threshold`, `smart_min_chars`, `chunk_max_placeholders_per_segment`, `chunk_max_segments`, `chunk_max_chars`, and `chunk_min_chars_for_merge` (initial conservative defaults implemented). 
- Extended `TranslationReport` with structured tuning metrics and traces including SAFE/SMART counts, `llm_chunks_built`, chunk/segment fallback counters, avg/max chunk size, avg LLM latency per segment/chunk, `llm_calls_saved_by_chunking`, `validation_failures` breakdown, placeholder mismatch counters, `routing_reasons`, and per-segment `routing_trace` and per-chunk `chunk_trace`.
- Routing decision traceability with human-readable reasons (examples: `short_plain_segment`, `technical_token_density`, `high_placeholder_density`, `multi_sentence_prose`, `long_natural_language_segment`) implemented in `decide_llm_postedit`.
- Chunk planning traceability implemented in `build_llm_chunks` including `segment_indices`, `mode`, `char_count`, `placeholder_density`, `merge_reason`, and `boundary_reason` (e.g. `merged_consecutive_prose_segments`, `stopped_due_to_max_chars`, `stopped_due_to_mode_change`).
- LLM latency plumbing added to per-segment outcomes (`PostEditOutcome.llm_latency_seconds`) and aggregated per-segment / per-chunk latency statistics recorded.
- Report export and summarizer: extended JSON/text reporting (`report_to_dict` / `format_report`) and added a lightweight CLI command `local-translator report-summary <run1.json> [run2.json ...]` (implements `summarize_reports`) to aggregate multiple run reports for tuning insights.
- Minor pipeline updates to collect routing counts/traces, chunk traces, validation failure counters, and estimated LLM calls saved by chunking; implemented without probabilistic or external systems to keep determinism.

### Testing
- Ran targeted integration checks: `pytest -q tests/integration/test_pipeline_text.py::test_pipeline_chunking_merges_three_segments_into_one_llm_call tests/integration/test_pipeline_text.py::test_pipeline_chunking_falls_back_to_per_segment_when_markers_invalid tests/integration/test_pipeline_text.py::test_pipeline_hybrid_skips_llm_for_short_segments tests/integration/test_cli_reporting.py::test_text_report_json_export`, which passed.
- Ran broader integration suites: `pytest -q tests/integration/test_cli_reporting.py tests/integration/test_pipeline_text.py`, which passed.
- Attempted full `pytest -q` in this environment but collection failed with `ModuleNotFoundError: No module named 'tests.integration'` (import-path/test-collection issue in this execution environment), so full-suite run could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c986de9fb0832bb4170f66dfbf4dc8)